### PR TITLE
Fix keys in chrome

### DIFF
--- a/PresentationKit/JQuery.idr
+++ b/PresentationKit/JQuery.idr
@@ -22,13 +22,13 @@ appendTo elm to =
   mkForeign (FFun "%0.append(%1)" [FPtr, FPtr] FUnit) to elm
 
 private
-unbindKeypress : IO Ptr
-unbindKeypress =
-  mkForeign (FFun "$(document).unbind('keypress')" [] FPtr)
+unbindKeydown : IO Ptr
+unbindKeydown =
+  mkForeign (FFun "$(document).unbind('keydown')" [] FPtr)
 
-onKeypress : (Ptr -> IO ()) -> IO ()
-onKeypress f = do
-  unbindKeypress
-  mkForeign (FFun "$(document).keypress(%0)" [
+onKeydown : (Ptr -> IO ()) -> IO ()
+onKeydown f = do
+  unbindKeydown
+  mkForeign (FFun "$(document).keydown(%0)" [
       FFunction FPtr (FAny (IO ()))
     ] FUnit) f

--- a/PresentationKit/Presentation.idr
+++ b/PresentationKit/Presentation.idr
@@ -26,16 +26,16 @@ previousSlide {n} {m} (MkPresentation (slide :: prev) next) =
   rewrite plusSuccRightSucc n m in
           MkPresentation prev (slide :: next)
 
-getKey : Ptr -> IO String
+getKey : Ptr -> IO Int
 getKey p =
-  mkForeign (FFun "%0.key" [FPtr] FString) p
+  mkForeign (FFun "%0.which" [FPtr] FInt) p
 
 bindKeys : IO () -> IO () -> IO ()
 bindKeys left right = do
-  onKeypress (\event => do case !(getKey event) of
-                                "Left"  => left
-                                "Right" => right
-                                _       => return ())
+  onKeydown (\event => do case !(getKey event) of
+                                37 => left
+                                39 => right
+                                _  => return ())
 
 slideWrapper : String -> List HTML -> HTML
 slideWrapper id nodes =


### PR DESCRIPTION
Neither keypress nor event.key work in chrome :-(

http://stackoverflow.com/questions/6311290/keypress-event-not-working-in-ie-and-chrome-but-working-in-ff/6311439#6311439
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent.key#Browser_compatibility
